### PR TITLE
Add manage command to warm the tile cache

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -15,6 +15,7 @@ psycopg2-binary = "==2.7.4"
 mercantile = "==1.0.1"
 clover = { git = 'https://github.com/consbio/clover.git' }
 pyproj = "*"
+aiohttp = "*"
 
 [requires]
 python_version = "3.6"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "0719f9cd44828ce71f41035704ca159df3ff469b428648102aefe00619267564"
+            "sha256": "59d748131ec5d11a4f025a61e0c120f8ce319cc7b1149e6bfab6be62c74cf09e"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -23,12 +23,40 @@
             ],
             "version": "==2.2.0"
         },
+        "aiohttp": {
+            "hashes": [
+                "sha256:1a3cee4cd10de0ce6c37d7a35f437baa70ca87272a0ccd3d3e1a0383de2f189a",
+                "sha256:25983293a073ae530bd4027fb82a9f16fcfe48335873582946d2dc3ed64337f0",
+                "sha256:33630a2dc90fee1e05bd1b57cde51d65b571c61494a1a91772c8bc0896acb5c8",
+                "sha256:390c1a2c7799519b3755a6e3f660842c3b1544e92a10ecd309ea97ce5c8c713d",
+                "sha256:52fcb205ab8a43ddaf182c928f84e998a02213139b2b2636a26249569d9518bd",
+                "sha256:5c5de2bc5004c2c60e5f256978ad711c1fb4dca00890ac7884ed92c6aa520608",
+                "sha256:65b61cec34628c5a2e047f93555d93c29f4e29169839b421f62206b9f317f7ae",
+                "sha256:98f0172f7760597b636431b7651f020b8dba6a816b2d7e263afa54a4f2f4d0a6",
+                "sha256:9fcef0489e3335b200d31a9c1fb6ba80fdafe14cd82b971168c2f9fa1e4508ad",
+                "sha256:aeb5f0ef22896122fa5a84bf37202d3f6ee2404f12176608259bc408509f4883",
+                "sha256:b03578ad3f5ba6fa8b8614bd3628c4c33de92bd23af95ebd8f4de66bac35d3d8",
+                "sha256:bc50ec0dd5887844653ce5d2dd5dab93fd2e2af44d4be65d6d5306fb4039f2bf",
+                "sha256:c7a55a2bf7433ddf753ed46cf5a733c787524a41b933799541075dd8db9ead1b",
+                "sha256:f883507d537a838d496755a14a41f2c34c7af5f39d7627e15d6b2a27578705b7",
+                "sha256:feb271ced50b689b2e4d969a5bfb0a1cfd0cc05dd11cdde4e42d93e009e0b900"
+            ],
+            "index": "pypi",
+            "version": "==3.1.3"
+        },
         "amqp": {
             "hashes": [
                 "sha256:4e28d3ea61a64ae61830000c909662cb053642efddbe96503db0e7783a6ee85b",
                 "sha256:cba1ace9d4ff6049b190d8b7991f9c1006b443a5238021aca96dd6ad2ac9da22"
             ],
             "version": "==2.2.2"
+        },
+        "async-timeout": {
+            "hashes": [
+                "sha256:00cff4d2dce744607335cba84e9929c3165632da2d27970dbc55802a0c7873d0",
+                "sha256:9093db5b8ddbe4b8f6885d1a6e0ad84ae3155464cbf6877c387605244c285f3c"
+            ],
+            "version": "==2.0.1"
         },
         "attrs": {
             "hashes": [
@@ -147,6 +175,12 @@
             ],
             "version": "==2.6"
         },
+        "idna-ssl": {
+            "hashes": [
+                "sha256:1293f030bc608e9aa9cdee72aa93c1521bbb9c7698068c61c9ada6772162b979"
+            ],
+            "version": "==1.0.1"
+        },
         "jinja2": {
             "hashes": [
                 "sha256:74c935a1b8bb9a3947c50a54766a969d4846290e1e788ea44c1392163723c3bd",
@@ -183,6 +217,33 @@
                 "sha256:c9ce7eccdcb901a2c75d326ea134e0886abfbea5f93e91cc95de9507c0816c44"
             ],
             "version": "==4.1.0"
+        },
+        "multidict": {
+            "hashes": [
+                "sha256:0dcf4f2893bf22839c7bd825f688d5fe60c8eb989b4eb817103a71d7f84058e5",
+                "sha256:1524bb334b605f6c7cf447e19e70d6fb96f68aefefe018bdceb9674572548c45",
+                "sha256:1b93d1b72b12566a6e238acb4f547cdf6de069c5b555faabfe9071852434b61a",
+                "sha256:24052724195e46872739faa10c611957bbaceae28eec92e1ce49150b115ec5ed",
+                "sha256:27643705c5a04cfbf7834b914e5367618f77b2692f920c734b18f476ea328f04",
+                "sha256:2b07135edc953e6a7e94d8628868715093efb015fc6a0ebf54c5ecd84064e5f8",
+                "sha256:3876b617228d60d655062f9ddaecb0f770777b8ae753e661de9a7d5eb4ef2933",
+                "sha256:3f11e31935d20822c977397e9ec868ab2287c82461bc74663c7df1bd8a5b61d0",
+                "sha256:4e0dbf5a204c462d6b129b9598e5124077244a9b91c255c5341f679472dc54a5",
+                "sha256:5a56ec27a528fce6a3fdf537929b039b8af01edec761b09f7fcde3915d3fbbe7",
+                "sha256:5bd46d01a49264f059d4c7b1f26cb5cbbcacb549edb77ad5caa2070ec4bffe47",
+                "sha256:6e5128658f82cd8d1830f159027c2be0af496b1b6aa710353a6c862a9285bc89",
+                "sha256:6ef4cf27db3424bcc6e7f9ead3abee53bca2c3a1db5821585cb3e386ae55178f",
+                "sha256:7aeccfbc7ccc29dcceca11ee295f5a267b093d90cf50808d4649d87e72bdbd89",
+                "sha256:7c43ca71db568e13d301e3a6153996a3e0da5d4b19c3517d2418fa5775d2d173",
+                "sha256:9deae50f23511e5639fadf8df68917027535e090b163c5bbb03e26f6a208dbfc",
+                "sha256:aab8e9063ff623387f72c04b55c43211da2edd4e0db9943057522a995c330877",
+                "sha256:ae1002b4c793a6b88c8208c8a312038185ffcf76a57fdbe6c5d0f62052737a65",
+                "sha256:af340843de65c4d678379e8e0b5bcfd2e614da8ed666f1ba006704fe456edbba",
+                "sha256:d3161a3697f8a332aa86da1402f4020499d50ccedc6eb3d8a40d5e3aca3c2afd",
+                "sha256:eafe84d62e45b17c82483a6b4b1a9757c91a1d6d9511d8b32ded52936582fdcb",
+                "sha256:f16c517bb33c8ce75ba5e8d5212e3591bc59f4ab837b5b9906a3ee5868180449"
+            ],
+            "version": "==4.2.0"
         },
         "munch": {
             "hashes": [
@@ -491,6 +552,24 @@
                 "sha256:6849544be74ec3638e84d90bc1cf2e1e9224cc10d96cd4383ec3f69e9bce077b"
             ],
             "version": "==1.1.4"
+        },
+        "yarl": {
+            "hashes": [
+                "sha256:045dbba18c9142278113d5dc62622978a6f718ba662392d406141c59b540c514",
+                "sha256:17e57a495efea42bcfca08b49e16c6d89e003acd54c99c903ea1cb3de0ba1248",
+                "sha256:213e8f54b4a942532d6ac32314c69a147d3b82fa1725ca05061b7c1a19a1d9b1",
+                "sha256:3353fae45d93cc3e7e41bfcb1b633acc37db821d368e660b03068dbfcf68f8c8",
+                "sha256:51a084ff8756811101f8b5031a14d1c2dd26c666976e1b18579c6b1c8761a102",
+                "sha256:5580f22ac1298261cd24e8e584180d83e2cca9a6167113466d2d16cb2aa1f7b1",
+                "sha256:64727a2593fdba5d6ef69e94eba793a196deeda7152c7bd3a64edda6b1f95f6e",
+                "sha256:6e75753065c310befab71c5077a59b7cb638d2146b1cfbb1c3b8f08b51362714",
+                "sha256:7236eba4911a5556b497235828e7a4bc5d90957efa63b7c4b3e744d2d2cf1b94",
+                "sha256:a69dd7e262cdb265ac7d5e929d55f2f3d07baaadd158c8f19caebf8dde08dfe8",
+                "sha256:d9ca55a5a297408f08e5401c23ad22bd9f580dab899212f0d5dc1830f0909404",
+                "sha256:e072edbd1c5628c0b8f97d00cf6c9fcd6a4ee2b5ded10d463fcb6eaa066cf40c",
+                "sha256:e9a6a319c4bbfb57618f207e86a7c519ab0f637be3d2366e4cdac271577834b8"
+            ],
+            "version": "==1.1.1"
         }
     },
     "develop": {}

--- a/codedeploy/after_install_spht.sh
+++ b/codedeploy/after_install_spht.sh
@@ -5,3 +5,4 @@ source $HOME/venv/spht/bin/activate
 cd $HOME/apps/spht
 python manage.py migrate --noinput
 python manage.py collectstatic --noinput
+python manage.py warm_tile_cache

--- a/spht/management/commands/warm_tile_cache.py
+++ b/spht/management/commands/warm_tile_cache.py
@@ -8,7 +8,7 @@ from ncdjango.models import Service
 from pyproj import Proj
 from django.conf import settings
 
-ZOOM_LEVELS = list(range(10))
+ZOOM_LEVELS = list(range(7))
 WGS84 = Proj('+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs')
 TILE_URL = 'http://127.0.0.1/tiles/{service}/{z}/{x}/{y}.png'
 MAX_CONCURRENCY = 10

--- a/spht/management/commands/warm_tile_cache.py
+++ b/spht/management/commands/warm_tile_cache.py
@@ -10,7 +10,7 @@ from django.conf import settings
 
 ZOOM_LEVELS = list(range(10))
 WGS84 = Proj('+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs')
-TILE_URL = 'http://127.0.0.1:8000/tiles/{service}/{z}/{x}/{y}.png'
+TILE_URL = 'http://127.0.0.1/tiles/{service}/{z}/{x}/{y}.png'
 MAX_CONCURRENCY = 10
 
 

--- a/spht/management/commands/warm_tile_cache.py
+++ b/spht/management/commands/warm_tile_cache.py
@@ -1,0 +1,53 @@
+import asyncio
+from itertools import islice
+
+import aiohttp
+import mercantile
+from django.core.management import BaseCommand
+from ncdjango.models import Service
+from pyproj import Proj
+from django.conf import settings
+
+ZOOM_LEVELS = list(range(10))
+WGS84 = Proj('+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs')
+TILE_URL = 'http://127.0.0.1:8000/tiles/{service}/{z}/{x}/{y}.png'
+MAX_CONCURRENCY = 10
+
+
+class Command(BaseCommand):
+    help = 'Warm the nginx tile cache for slower, low zoom levels'
+
+    async def fetch_tile(self, session, service, tile):
+        try:
+            host = settings.ALLOWED_HOSTS[0]
+        except IndexError:
+            host = '127.0.0.1'
+
+        headers = {'host': host}
+        await session.get(TILE_URL.format(service=service, z=tile.z, x=tile.x, y=tile.y), headers=headers)
+
+    async def fetch_tiles(self, tiles):
+        async with aiohttp.ClientSession() as session:
+            coroutines = (self.fetch_tile(session, *t) for t in tiles)
+            futures = set([asyncio.ensure_future(c) for c in islice(coroutines, 0, MAX_CONCURRENCY)])
+
+            while True:
+                await asyncio.sleep(0)
+                for f in futures:
+                    if f.done():
+                        futures.remove(f)
+                        try:
+                            futures.add(asyncio.ensure_future(next(coroutines)))
+                        except StopIteration:
+                            continue
+
+    def handle(self, *args, **kwargs):
+        tiles = []
+        for service in Service.objects.all():
+            extent = service.full_extent.project(WGS84)
+            tiles += [
+                (service.name, t) for t in
+                mercantile.tiles(extent.xmin, extent.ymin, extent.xmax, extent.ymax, ZOOM_LEVELS, truncate=True)
+            ]
+
+        asyncio.get_event_loop().run_until_complete(self.fetch_tiles(tiles))


### PR DESCRIPTION
This PR adds a manage command to warm the tile cache on the server as a post deploy step. The effect of running this on the server is to pre-populate the Nginx cache with rendered tiles for all services, substantially improving performance for users. Part of #12.